### PR TITLE
Added support for Rust 1.81.0 and newer

### DIFF
--- a/crates/chain/Cargo.toml
+++ b/crates/chain/Cargo.toml
@@ -23,6 +23,8 @@ eosio-macro = { version = "0.2", path = "../macro", default-features = false }
 chaintester = { version = "0.2", path = "../chaintester", default-features = false, optional = true }
 eosio-scale-info = { version="2.1.3",  default-features = false, features = ["derive"], optional = true }
 
+rustversion = "1.0"
+
 [features]
 default = ["std"]
 std = [


### PR DESCRIPTION
This PR addresses #8 by using conditional compilation to distinguish between Rust `1.81.0` and older versions.

It requires the `rustversion` crate for this purpose.

